### PR TITLE
A few pedantic reliability points

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,12 @@ MAINTAINER Corbin Uselton <corbinu@decimal.io>
 
 ENV TERM xterm
 
-RUN apt-get update
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  openssh-server \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
-RUN apt-get -yq install openssh-server; \
-  mkdir -p /var/run/sshd; \
+RUN mkdir -p /var/run/sshd; \
   mkdir /root/.ssh && chmod 700 /root/.ssh; \
   touch /root/.ssh/authorized_keys
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,14 @@ MAINTAINER Corbin Uselton <corbinu@decimal.io>
 ENV TERM xterm
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  openssh-server \
+    openssh-server \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /var/run/sshd && \
-  mkdir /root/.ssh && chmod 700 /root/.ssh && \
-  touch /root/.ssh/authorized_keys
+RUN mkdir -p /var/run/sshd \
+  && mkdir /root/.ssh \
+  && chmod 700 /root/.ssh \
+  && touch /root/.ssh/authorized_keys
 
 COPY bin/* /usr/local/bin/
 COPY sshd_config /etc/ssh/sshd_config
@@ -19,3 +20,5 @@ EXPOSE 22
 
 ENTRYPOINT ["ssh-start"]
 CMD ["ssh-server"]
+
+COPY authorized_keys /root/.ssh/authorized_keys

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
-RUN mkdir -p /var/run/sshd; \
-  mkdir /root/.ssh && chmod 700 /root/.ssh; \
+RUN mkdir -p /var/run/sshd && \
+  mkdir /root/.ssh && chmod 700 /root/.ssh && \
   touch /root/.ssh/authorized_keys
 
 COPY bin/* /usr/local/bin/

--- a/bin/ssh-start
+++ b/bin/ssh-start
@@ -4,7 +4,7 @@ set -e
 
 if [ "$1" = 'ssh-server' ]
 then
-    /usr/sbin/sshd -D
+    exec /usr/sbin/sshd -D
 fi
 
 exec "$@"

--- a/sshd_config
+++ b/sshd_config
@@ -82,4 +82,4 @@ Subsystem sftp /usr/lib/openssh/sftp-server
 # If you just want the PAM account and session checks to run without
 # PAM authentication, then enable this but set PasswordAuthentication
 # and ChallengeResponseAuthentication to 'no'.
-UsePAM yes
+UsePAM no

--- a/sshd_config
+++ b/sshd_config
@@ -82,4 +82,4 @@ Subsystem sftp /usr/lib/openssh/sftp-server
 # If you just want the PAM account and session checks to run without
 # PAM authentication, then enable this but set PasswordAuthentication
 # and ChallengeResponseAuthentication to 'no'.
-UsePAM no
+UsePAM yes


### PR DESCRIPTION
`UsePAM` is better as `off` if we’re cutting off all logins except private keys. PAM can actually do some weird and unexpected things like allow password-based logins even though one has disabled them.

`apt-get` commands should run as a chain, so that it allows better caching. Update, install, and cleanup all in one step and then the interm downloads and caches do not end up in the docker image cache.

Also, using `--no-install-recommends` keeps ubuntu from installing extra packages that ubuntu thinks one might want just because one is installing `openssh-server`.

The `mkdir` series should be run as a `&&` chain, otherwise a successful `touch` could swallow the error state from a failed `mkdir` or `chmod`, and docker would continue building the image even though it is technically in a fail state.

When using a shell script to bootstrap an execution, the command should be invoked with an `exec`, otherwise, the intended executable does not run as the primary PID, does not receive signals, and a lot of weird funky problems happen. Also, if `sshd` ever quit, execution would carry on into the `exec "$@"` which could cause unexpected and weird bugs.

Allowing X11Forwarding is also debatable, as there are significant security caveats to keep in mind, and would there be any X applications on the docker image anyways? But in the end, I elected against turn it off, because as noted, it is debatable, not “definitively a better choice”, and maybe people are expecting this functionality?