### PR TITLE
Update file permissions on authorized_keys to 600

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,3 +22,4 @@ ENTRYPOINT ["ssh-start"]
 CMD ["ssh-server"]
 
 COPY authorized_keys /root/.ssh/authorized_keys
+RUN chmod 600 /root/.ssh/authorized_keys


### PR DESCRIPTION
I was unable to ssh in without manually updating the authorized_keys file.  Was getting the error below before making this tweak.

```
$ ssh root@<external lb IP>
The authenticity of host '<external lb IP> (<external lb IP>)' can't be established.
ED25519 key fingerprint is SHA256:<big sha>
This key is not known by any other names
Are you sure you want to continue connecting (yes/no/[fingerprint])? yes
Warning: Permanently added '<external lb IP>' (ED25519) to the list of known hosts.
root@<external lb IP>: Permission denied (publickey).
```

RE: https://askubuntu.com/a/46425